### PR TITLE
Clear properties prior to writing new ones

### DIFF
--- a/default.py
+++ b/default.py
@@ -52,6 +52,15 @@ class Main:
 
     def _set_properties(self, listing):
         self.WINDOW = xbmcgui.Window(10000)
+        oldcount = 0
+        try:
+            oldcount = int(self.WINDOW.getProperty("favourite.count"))
+        except:
+            pass
+        for idx_count in range(1,oldcount + 1):
+            self.WINDOW.clearProperty("favourite.%d.path" % (idx_count))
+            self.WINDOW.clearProperty("favourite.%d.name" % (idx_count))
+            self.WINDOW.clearProperty("favourite.%d.thumb" % (idx_count))
         self.WINDOW.setProperty("favourite.count", str(len(listing)))
         for count, favourite in enumerate(listing):
             name = favourite.attributes[ 'name' ].nodeValue


### PR DESCRIPTION
Motivation for this PR is that a skin displays favourite widgets on the home page.  Currently the skin displays up to 12 widgets if the favourite properties exist as a vis condition.  The script does not remove stale properties after favourite deletion, resulting in stale widgets.  The skin could add vis conditions based on Integer.IsLessOrEqual(Window.Property(favourite.count),number) but I think it is better if the script removes its unneeded properties.

This was tested on ver 6.0.3 (Jarvis branch) and ver 7.1.0 (master branch) on Kodi 17 Beta 5 Win32

This commit will clear the existing (if any) home window favourite
properties prior to writing the new ones.  This will remove stale
properties when favourites have been deleted.